### PR TITLE
fix: prevent language-switcher crash on unmapped locale

### DIFF
--- a/app/Livewire/LanguageSwitcher.php
+++ b/app/Livewire/LanguageSwitcher.php
@@ -8,28 +8,42 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 use Livewire\Features\SupportRedirects\Redirector;
 
 class LanguageSwitcher extends Component
 {
-    public string $currentLocale = '';
-
     /** @var array<string, string> */
-    public array $availableLocales = [
+    private const LOCALES = [
         'de' => 'DE',
         'en' => 'EN',
     ];
+
+    public string $currentLocale = '';
 
     public function mount(): void
     {
         $this->currentLocale = App::getLocale();
     }
 
+    /**
+     * Server-authoritative locale map. Exposed as a computed property so it is
+     * never carried in the Livewire snapshot, preventing stale client payloads
+     * from rehydrating it into an inconsistent state.
+     *
+     * @return array<string, string>
+     */
+    #[Computed]
+    public function availableLocales(): array
+    {
+        return self::LOCALES;
+    }
+
     public function switchLanguage(string $locale): RedirectResponse|Redirector|null
     {
         // Validate locale
-        if (! array_key_exists($locale, $this->availableLocales)) {
+        if (! array_key_exists($locale, self::LOCALES)) {
             return null;
         }
 

--- a/resources/views/livewire/language-switcher.blade.php
+++ b/resources/views/livewire/language-switcher.blade.php
@@ -1,11 +1,11 @@
 <flux:dropdown position="bottom" align="end">
     <flux:button variant="ghost" icon-trailing="chevron-down" size="sm">
-        <span class="max-sm:sr-only">{{ $availableLocales[$currentLocale] }}</span>
+        <span class="max-sm:sr-only">{{ $this->availableLocales[$currentLocale] ?? strtoupper($currentLocale) }}</span>
     </flux:button>
 
     <flux:menu>
         <flux:menu.heading>{{ __('Language') }}</flux:menu.heading>
-        @foreach($availableLocales as $locale => $language)
+        @foreach($this->availableLocales as $locale => $language)
             <flux:menu.item
                 wire:click="switchLanguage('{{ $locale }}')"
                 icon="{{ $currentLocale === $locale ? 'check' : '' }}"

--- a/tests/Feature/LanguageSwitcherTest.php
+++ b/tests/Feature/LanguageSwitcherTest.php
@@ -1,4 +1,4 @@
-It shou<?php
+<?php
 
 use App\Livewire\LanguageSwitcher;
 use App\Models\User;
@@ -73,4 +73,17 @@ it('highlights current language', function () {
     Livewire::test(LanguageSwitcher::class)
         ->assertSet('currentLocale', 'en')
         ->assertSee('EN');
+});
+
+it('renders without error when the active locale is not in the map', function () {
+    $this->actingAs($this->user);
+
+    // A regional or unknown locale (e.g. from an Accept-Language header or a
+    // stale user preference) must not crash the switcher's label lookup.
+    App::setLocale('de_DE');
+
+    Livewire::test(LanguageSwitcher::class)
+        ->assertSet('currentLocale', 'de_DE')
+        ->assertOk()
+        ->assertSee('DE_DE');
 });


### PR DESCRIPTION
## Problem
Production logged an intermittent `Undefined array key "de"` `ViewException` in `resources/views/livewire/language-switcher.blade.php` (seen 07-16 and 07-22, before the version upgrade — this is a pre-existing bug, not caused by it).

## Root cause
The locale map was a **public Livewire property** (`$availableLocales`), so it was serialized into the component snapshot and rehydrated from the client on every roundtrip. After a deploy, browsers/crawlers replay **stale but still checksum-valid** snapshots (APP_KEY is unchanged), which rehydrate `availableLocales` into a shape missing the active locale's key → the label lookup `$availableLocales[$currentLocale]` throws.

## Fix
- Move the map to a `private const LOCALES`, exposed via a `#[Computed]` property so it is always **server-derived** and never part of the client snapshot.
- Null-safe the label lookup (`?? strtoupper($currentLocale)`) so an out-of-map active locale (e.g. a regional `de_DE` from a user preference or `Accept-Language`) can't crash rendering either.
- Add a regression test covering an active locale that isn't in the map.
- Remove stray `It shou` text that was corrupting the top of the test file.

## Testing
- `LanguageSwitcherTest`: 7 passed (incl. new regression test)
- Full suite: **244 passed**
- Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)